### PR TITLE
Added custom hook parameter to Slack::Notifier.

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -11,11 +11,12 @@ module Slack
     # if they are set
     attr_accessor :channel, :username
 
-    attr_reader :team, :token
+    attr_reader :team, :token, :hook_name
 
-    def initialize team, token
+    def initialize team, token, hook_name = default_hook_name
       @team  = team
       @token = token
+      @hook_name = hook_name
     end
 
     def ping message, options={}
@@ -31,6 +32,10 @@ module Slack
 
     private
 
+      def default_hook_name
+        'incoming-webhook'
+      end
+
       def default_payload
         payload = {}
         payload[:channel]  = channel  if channel
@@ -39,7 +44,7 @@ module Slack
       end
 
       def endpoint
-        URI.parse "https://#{team}.slack.com/services/hooks/incoming-webhook?token=#{token}"
+        URI.parse "https://#{team}.slack.com/services/hooks/#{hook_name}?token=#{token}"
       end
 
   end

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,16 @@ notifier.ping "Hello random", channel: "#random"
 # => will ping the "#random" channel
 ```
 
+### Custom hook name
+
+When Slack integrates an app with their website, they replace `incoming-webhook` with the service name.
+This allows you to use this library to integrate a non-DIY service.
+
+```ruby
+notifier = Slack::Notifier.new "yourteam", "yourtokenXX", "custom_hook_name"
+# => Messages will be posted to https://yourteam.slack.com/services/hooks/custom_hook_name
+```
+
 ## Links
 
 Slack requires links to be formatted a certain way, so slack-notifier will look through your message and attempt to convert any html or markdown links to slack's format before posting.

--- a/spec/lib/slack-notifier_spec.rb
+++ b/spec/lib/slack-notifier_spec.rb
@@ -12,6 +12,11 @@ describe Slack::Notifier do
       subject = described_class.new 'team', 'token'
       expect( subject.token ).to eq 'token'
     end
+
+    it 'sets the optional service hook name' do
+      subject = described_class.new 'team', 'token', 'custom_hook_name'
+      expect( subject.hook_name ).to eq 'custom_hook_name'
+    end
   end
 
   describe "#ping" do
@@ -73,6 +78,17 @@ describe Slack::Notifier do
                                 payload: '{"text":"the message","channel":"channel"}'
 
         described_class.new("team","token").ping "the message", channel: "channel"
+    end
+
+    context 'custom hook name' do
+      it 'posts to the correct endpoint' do
+        allow( Net::HTTP ).to receive(:post_form)
+        @endpoint_double = instance_double "URI::HTTP"
+        allow( URI ).to receive(:parse)
+                    .with("https://team.slack.com/services/hooks/custom_hook_name?token=token")
+                    .and_return(@endpoint_double)
+        described_class.new('team','token','custom_hook_name').ping "the message", channel: 'foo'
+      end
     end
   end
 


### PR DESCRIPTION
Hi there, thank you for having written this library.
I've used it to add Slack integration to Gitlab. When Slack creates the service on their side, we need to be able to pass in a custom hook name (i.e. `gitlab`) and this PR enables just that.
Please let me know what I can do better to get this merged. :)
