### PR TITLE
Remove channel ArgumentError

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -23,10 +23,6 @@ module Slack
       message = LinkFormatter.format(message)
       payload = { text: message }.merge(default_payload).merge(options)
 
-      unless payload.has_key? :channel
-        raise ArgumentError, "You must set a channel"
-      end
-
       Net::HTTP.post_form endpoint, payload: payload.to_json
     end
 

--- a/spec/lib/slack-notifier_spec.rb
+++ b/spec/lib/slack-notifier_spec.rb
@@ -31,12 +31,6 @@ describe Slack::Notifier do
       described_class.new('team','token').ping "the message", channel: 'foo'
     end
 
-    it "requires a channel to be set" do
-      expect{
-        described_class.new('team','token').ping "the message"
-      }.to raise_error
-    end
-
     context "with a default channel set" do
 
       before :each do


### PR DESCRIPTION
According to Slack doc, if we didn't spcifiy a channel in payload, it will fallback to the one we set when adding integration.
