### PR TITLE
fixed EOFError due failed TLS negotiation

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -23,7 +23,11 @@ module Slack
       message = LinkFormatter.format(message)
       payload = { text: message }.merge(default_payload).merge(options)
 
-      Net::HTTP.post_form endpoint, payload: payload.to_json
+      req = Net::HTTP::Post.new(endpoint.request_uri)
+      req.set_form_data(payload: payload.to_json)
+      http = Net::HTTP.new(endpoint.host, endpoint.port)
+      http.use_ssl = (endpoint.scheme == "https")
+      http.request(req)
     end
 
     private


### PR DESCRIPTION
Hi,

I wanted to use slack support in gitlab, but always got a EOFError on ping. 

```
/usr/local/lib/ruby/1.9.1/net/protocol.rb:141:in `read_nonblock': end of file reached (EOFError)
    from /usr/local/lib/ruby/1.9.1/net/protocol.rb:141:in `rbuf_fill'
    from /usr/local/lib/ruby/1.9.1/net/protocol.rb:122:in `readuntil'
    from /usr/local/lib/ruby/1.9.1/net/protocol.rb:132:in `readline'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:2562:in `read_status_line'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:2551:in `read_new'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:1319:in `block in transport_request'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:1316:in `catch'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:1316:in `transport_request'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:1293:in `request'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:483:in `block in post_form'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:745:in `start'
    from /usr/local/lib/ruby/1.9.1/net/http.rb:482:in `post_form'
    from /tmp/slack-notifier/lib/slack-notifier.rb:26:in `ping'
    from test.rb:5:in `<main>'
```

I tracked down the problem and found the solution here: http://stackoverflow.com/questions/5244887/eoferror-end-of-file-reached-issue-with-nethttp

Seems to be connected with this issue: https://gitlab.com/gitlab-org/gitlab-ce/issues/155

How is it possible that it worked for you?
