### PR TITLE
Force UTF-8 encoding before pushing so Slack

### DIFF
--- a/lib/slack-notifier/link_formatter.rb
+++ b/lib/slack-notifier/link_formatter.rb
@@ -30,9 +30,9 @@ module Slack
 
         def fix_encoding string
           string.encode 'UTF-8',
+            'binary',
             :invalid => :replace,
-            :undef   => :replace,
-            :replace => "\uFFFD"
+            :undef   => :replace
         end
 
         def slack_link link, text=nil

--- a/lib/slack-notifier/link_formatter.rb
+++ b/lib/slack-notifier/link_formatter.rb
@@ -11,7 +11,7 @@ module Slack
       end
 
       def initialize string
-        @orig = string
+        @orig = fix_encoding string
       end
 
       def formatted
@@ -27,6 +27,14 @@ module Slack
       end
 
       private
+
+        def fix_encoding string
+          transcoding_options = {
+            :invalid => :replace,
+            :undef => :replace,
+            :replace => '?'}
+          string.encode 'UTF-8', transcoding_options
+        end
 
         def slack_link link, text=nil
           out = "<#{link}"

--- a/lib/slack-notifier/link_formatter.rb
+++ b/lib/slack-notifier/link_formatter.rb
@@ -29,11 +29,10 @@ module Slack
       private
 
         def fix_encoding string
-          transcoding_options = {
+          string.encode 'UTF-8',
             :invalid => :replace,
-            :undef => :replace,
-            :replace => '?'}
-          string.encode 'UTF-8', transcoding_options
+            :undef   => :replace,
+            :replace => "\uFFFD"
         end
 
         def slack_link link, text=nil

--- a/spec/lib/slack-notifier/link_formatter_spec.rb
+++ b/spec/lib/slack-notifier/link_formatter_spec.rb
@@ -37,6 +37,17 @@ describe Slack::Notifier::LinkFormatter do
       expect( formatted ).to include("<http://example2.com|this2>")
     end
 
+    it "handles invalid unicode sequences" do
+      expect {
+        described_class.format("This sequence is invalid: \255")
+      }.not_to raise_error
+    end
+
+    it "replaces invalid unicode sequences with the unicode replacement character" do
+      formatted = described_class.format("\255")
+      expect(formatted).to eq "\uFFFD"
+    end
+
   end
 
 end


### PR DESCRIPTION
Hello,

I had issues when logging exceptions built from http responsse that come in with non-utf8 encoding and raise Encoding::UndefinedConversionError (basically they have invalid characters...).

This patch forces the encoding to UTF-8 in the LinkFormatter class to avoid this issue, whatever the content of the message.