### PR TITLE
Fix LinkFormatter for valid Japanese

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 
 group :development do
-  gem 'pry-byebug'
+  gem 'pry-byebug' if RUBY_VERSION >= '2.0.0'
   gem 'wwtd'
   gem 'travis'
 end

--- a/lib/slack-notifier/link_formatter.rb
+++ b/lib/slack-notifier/link_formatter.rb
@@ -1,3 +1,5 @@
+require 'string-scrub' if RUBY_VERSION < '2.1.0'
+
 module Slack
   class Notifier
     class LinkFormatter
@@ -11,7 +13,7 @@ module Slack
       end
 
       def initialize string
-        @orig = fix_encoding string
+        @orig = string.scrub
       end
 
       def formatted
@@ -27,13 +29,6 @@ module Slack
       end
 
       private
-
-        def fix_encoding string
-          string.encode 'UTF-8',
-            'binary',
-            :invalid => :replace,
-            :undef   => :replace
-        end
 
         def slack_link link, text=nil
           out = "<#{link}"

--- a/slack-notifier.gemspec
+++ b/slack-notifier.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["spec/**/*.rb"]
   s.require_path  = "lib"
 
+  s.add_dependency("string-scrub", "~> 0.0.5") if RUBY_VERSION < "2.1.0"
+
 end

--- a/spec/integration/ping_integration_test.rb
+++ b/spec/integration/ping_integration_test.rb
@@ -1,5 +1,7 @@
+# coding: utf-8
+
 require_relative '../../lib/slack-notifier'
 
 notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'], username: 'notifier'
 puts "testing with ruby #{RUBY_VERSION}"
-notifier.ping "hello from notifier test script on ruby: #{RUBY_VERSION}"
+notifier.ping "hello/こんにちは from notifier test script on ruby: #{RUBY_VERSION}"

--- a/spec/lib/slack-notifier/link_formatter_spec.rb
+++ b/spec/lib/slack-notifier/link_formatter_spec.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 require 'spec_helper'
 
 describe Slack::Notifier::LinkFormatter do
@@ -46,6 +48,11 @@ describe Slack::Notifier::LinkFormatter do
     it "replaces invalid unicode sequences with the unicode replacement character" do
       formatted = described_class.format("\255")
       expect(formatted).to eq "\uFFFD"
+    end
+
+    it "doesn't replace valid Japanese" do
+      formatted = described_class.format("こんにちは")
+      expect(formatted).to eq "こんにちは"
     end
 
   end


### PR DESCRIPTION
I can't use Japanese on message since version 1.2.0.
I fix it with `String#scrub`.

`String#scrub` is availabl on Ruby 2.1.0+ only, So I add [hsbt/string-scrub](https://github.com/hsbt/string-scrub) for Ruby 2.0 and 1.9.3

## Results of `$ bin/test`

### Before
![ss 2015-04-28 at 21 44 58](https://cloud.githubusercontent.com/assets/1041857/7370072/6017166a-edf2-11e4-8a41-5acae605852f.png)

### After
![ss 2015-04-28 at 21 45 05](https://cloud.githubusercontent.com/assets/1041857/7370073/60224c60-edf2-11e4-82f0-11ab483ed0ba.png)