### PR TITLE
Prepend # to the channel name 

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -31,7 +31,8 @@ module Slack
     end
 
     def channel
-      default_payload[:channel]
+      c = default_payload[:channel]
+      c.start_with?("#") ? c : "##{c}"
     end
 
     def channel= channel

--- a/spec/lib/slack-notifier_spec.rb
+++ b/spec/lib/slack-notifier_spec.rb
@@ -10,7 +10,7 @@ describe Slack::Notifier do
 
     it "sets the default_payload options" do
       subject = described_class.new 'http://example.com', channel: 'foo'
-      expect( subject.channel ).to eq 'foo'
+      expect( subject.channel ).to eq '#foo'
     end
 
     it "sets a custom http client" do
@@ -93,6 +93,18 @@ describe Slack::Notifier do
 
         described_class.new('http://example.com',http_client: client).ping "the message"
       end
+    end
+  end
+
+  describe "#channel" do
+    it "prepends # to the channel if it doesn't exist" do
+      allow(subject).to receive(:default_payload).and_return({channel: "blah"})
+      expect( subject.channel ).to eq "#blah"
+    end
+
+    it "doesn't prepend # to the channel if it already exists" do
+      allow(subject).to receive(:default_payload).and_return({channel: "#blah"})
+      expect( subject.channel ).to eq "#blah"
     end
   end
 


### PR DESCRIPTION
Prepend # to the channel name if it doesn't exist because the Slack API raises an exception if the channel name doesn't start with #

Slack gives an obscure error message when the channel name is not prepended with # (e.g. if you use "some_channel" instead of "#some_channel").  I ran into this problem once myself and my coworker ran into the same problem today, so I think this fix will save some headaches.  Thanks!