### PR TITLE
Add `#escape` to allow clients to escape special characters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 1.3.0 - unreleased
+- Add `#escape` to allow clients to escape special characters
+
 # 1.2.1
 - use `#scrub` to (more selectively) strip invalid characters from strings before attempting to format. This allows valid japanese (and more) characters to be used. Thanks to @fukayatsu for reporting.
 

--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -46,5 +46,11 @@ module Slack
       default_payload[:username] = username
     end
 
+    HTML_ESCAPE_REGEXP = /[&><]/
+    HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;' }
+
+    def escape(text)
+      text.gsub(HTML_ESCAPE_REGEXP, HTML_ESCAPE)
+    end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,16 @@ notifier.ping message
 
 You can see [Slack's message documentation here](https://api.slack.com/docs/formatting) 
 
+## Escaping
+
+Since sequences starting with < have special meaning in Slack, you should use `notifier.escape` if your messages may contain &, < or >.
+
+```ruby
+link_text = notifier.escape("User <user@example.com>")
+message = "Write to [#{link_text}](mailto:user@example.com)"
+notifier.ping message
+```
+
 ## Additional parameters
 
 Any key passed to the `ping` method is posted to the webhook endpoint. Check out the [Slack webhook documentation](https://my.slack.com/services/new/incoming-webhook) for the available parameters.

--- a/spec/lib/slack-notifier_spec.rb
+++ b/spec/lib/slack-notifier_spec.rb
@@ -109,4 +109,12 @@ describe Slack::Notifier do
       expect( subject.username ).to eq "foo"
     end
   end
+
+  describe "#escape" do
+    it "escapes sequences of < > &, but not quotes" do
+      message = %q(I've heard "Do > with <" & that sounds ridiculous.)
+      expected = %q(I've heard "Do &gt; with &lt;" &amp; that sounds ridiculous.)
+      expect( subject.escape(message) ).to eq expected
+    end
+  end
 end


### PR DESCRIPTION
I ran into an issue trying to make a link that contained the < character.

```
notifier.ping "Write to [User <user@example.com>](mailto:user@example.com)"
# Message posted to Slack:
# Write to <mailto:user@example.com%7CUser <user@example.com>>
```

The [Slack docs](https://api.slack.com/docs/formatting) mention escaping < > and &, but not " and ' so the `ERB::Utils.html_escape` doesn't work since it escapes quotes so you end up with &amp;#39; in your messages.

I suggest adding a Slack-specific `Notifier#escape` method that clients can use if they need.

I added a test, a section to the readme and a line to the changelog.