### PR TITLE
Fix a bug with markdown link formatter

### DIFF
--- a/lib/slack-notifier/link_formatter.rb
+++ b/lib/slack-notifier/link_formatter.rb
@@ -52,7 +52,7 @@ module Slack
         end
 
         def markdown_pattern
-          /\[(.*?)\]\((.+?)\)/
+          /\[([^\[\]]*?)\]\((https?:\/\/.*?)\)/
         end
 
     end

--- a/spec/lib/slack-notifier/link_formatter_spec.rb
+++ b/spec/lib/slack-notifier/link_formatter_spec.rb
@@ -15,6 +15,11 @@ describe Slack::Notifier::LinkFormatter do
       expect( formatted ).to include("<http://example.com|this>")
     end
 
+    it "formats markdown links in brackets" do
+      formatted = described_class.format("Hello World, enjoy [[this](http://example.com) in brackets].")
+      expect( formatted ).to eq("Hello World, enjoy [<http://example.com|this> in brackets].")
+    end
+
     it "formats markdown links with no title" do
       formatted = described_class.format("Hello World, enjoy [](http://example.com).")
       expect( formatted ).to include("<http://example.com>")


### PR DESCRIPTION
Fixes markdown like this:

```
Hello World, enjoy [[this](http://example.com) in brackets]
```

Previously, this returned:

```
Hello World, enjoy <http://example.com|[this> in brackets]
```

Now it correctly returns:

```
Hello World, enjoy [<http://example.com|this> in brackets]
```