### PR TITLE
Handle mailto link within markdown.

### DIFF
--- a/lib/slack-notifier/link_formatter.rb
+++ b/lib/slack-notifier/link_formatter.rb
@@ -54,7 +54,7 @@ module Slack
 
         # http://rubular.com/r/fLEdmTSghW
         def markdown_pattern
-          /\[ ([^\[\]]*?) \] \( (https?:\/\/.*?) \) /x
+          /\[ ([^\[\]]*?) \] \( ((https?:\/\/.*?) | (mailto:.*?)) \) /x
         end
 
     end

--- a/spec/lib/slack-notifier/link_formatter_spec.rb
+++ b/spec/lib/slack-notifier/link_formatter_spec.rb
@@ -63,6 +63,11 @@ describe Slack::Notifier::LinkFormatter do
       expect(formatted).to eq "こんにちは"
     end
 
+    it "handles email links in markdown" do
+      formatted = described_class.format("[John](mailto:john@example.com)")
+      expect(formatted).to eq "<mailto:john@example.com|John>"
+    end
+
   end
 
 end


### PR DESCRIPTION
As the title says. This fix enables markdown that contains `mailto` links to be converted into slack links.