### PR TITLE
OpenSSL::SSL::VERIFY_NONE on windows to avoid OpenSSL::SSL::SSLError

### DIFF
--- a/lib/slack-notifier/default_http_client.rb
+++ b/lib/slack-notifier/default_http_client.rb
@@ -33,7 +33,7 @@ module Slack
         def http_obj
           http = Net::HTTP.new uri.host, uri.port
           http.use_ssl = (uri.scheme == "https")
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE if net_http.use_ssl? 
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl? 
           
           http_options.each do |opt, val|
             if http.respond_to? "#{opt}="

--- a/lib/slack-notifier/default_http_client.rb
+++ b/lib/slack-notifier/default_http_client.rb
@@ -33,7 +33,8 @@ module Slack
         def http_obj
           http = Net::HTTP.new uri.host, uri.port
           http.use_ssl = (uri.scheme == "https")
-
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE if net_http.use_ssl? 
+          
           http_options.each do |opt, val|
             if http.respond_to? "#{opt}="
               http.send "#{opt}=", val

--- a/lib/slack-notifier/default_http_client.rb
+++ b/lib/slack-notifier/default_http_client.rb
@@ -29,11 +29,18 @@ module Slack
 
           return req
         end
-
+   
+        def ssl_chek_win(net)
+          case RUBY_PLATFORM
+            when /win/i, /ming/i
+              net.verify_mode = OpenSSL::SSL::VERIFY_NONE if net.use_ssl?
+            end
+        end
+        
         def http_obj
           http = Net::HTTP.new uri.host, uri.port
           http.use_ssl = (uri.scheme == "https")
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl? 
+          ssl_chek_win(http)
           
           http_options.each do |opt, val|
             if http.respond_to? "#{opt}="


### PR DESCRIPTION
SSL_connect returned =1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)