### PR TITLE
Let attachments pass single values to prevent typing [] in params

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -20,7 +20,7 @@ module Slack
       end
 
       if attachments = options[:attachments] || options["attachments"]
-        attachments.each do |attachment|
+        wrap_array(attachments).each do |attachment|
           ["text", :text].each do |key|
             attachment[key] = LinkFormatter.format(attachment[key]) if attachment.has_key?(key)
           end
@@ -66,6 +66,16 @@ module Slack
 
     def escape(text)
       text.gsub(HTML_ESCAPE_REGEXP, HTML_ESCAPE)
+    end
+
+    def wrap_array(object)
+      if object.nil?
+        []
+      elsif object.respond_to?(:to_ary)
+        object.to_ary || [object]
+      else
+        [object]
+      end
     end
   end
 end

--- a/spec/lib/slack-notifier_spec.rb
+++ b/spec/lib/slack-notifier_spec.rb
@@ -62,6 +62,19 @@ describe Slack::Notifier do
       }.not_to raise_error
     end
 
+    it "passes attachment messages through LinkFormatter, even if a single value is passed" do
+      expect( Slack::Notifier::LinkFormatter ).to receive(:format)
+                                              .with("a random message")
+      expect( Slack::Notifier::LinkFormatter ).to receive(:format)
+                                              .with("attachment message")
+      attachment = {
+        color: "#000",
+        text: "attachment message",
+        fallback: "fallback message"
+      }
+      subject.ping "a random message", attachments: attachment
+    end
+
     context "with a default channel set" do
 
       before :each do


### PR DESCRIPTION
I updated the ping function, so you can pass attachments with a single value.
I needed to implement a little helper function (#wrap_array) to prevent the hash being parsed as arrays like this:
```
a_ok_note = {
  fallback: "Everything looks peachy",
  text: "Everything looks peachy",
  color: "good"
}
Array(a_ok_note) # => [[:fallback, "Everything looks peachy"], [:text, "Everything looks peachy"], [:color, "good"]]
wrap_array(a_ok_note) # => [{:fallback=>"Everything looks peachy", :text=>"Everything looks peachy", :color=>"good"}]
```