### PR TITLE
Allow initialize to take a block

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -12,6 +12,7 @@ module Slack
     def initialize webhook_url, options={}
       @endpoint        = URI.parse webhook_url
       @default_payload = options
+      yield(self) if block_given?
     end
 
     def ping message, options={}


### PR DESCRIPTION
Alters api so that it can support taking a block

This allows Slack Notifier to be used as such:

```
Slack::Notifier.new 'webhook' do |notifier|
  notifier.ping {# some message definition }
end
```
