### PR TITLE
raise when the api returns a non successful response

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 2.2.0
+- raise exception when API responds with an error [@siegy22]
+
 # 2.1.0
 - addition of :at middleware to simplify notifying users & rooms [@kazuooooo #66]
 


### PR DESCRIPTION
This will somehow break our slack-notifier API. On successful
responses the flow will still be the same. In my projects I always
wrapped slack-notifier with a class which does excatly this. IMO when
there's an error with the slack API call shouldn't fail silently.

(I also added a changelog entry to indicate we should bump the version
from 2.1.0 to 2.2.0 to indicate that this could break the current code)