### PR TITLE
Prevent loading slack-notifier gem from breaking

### DIFF
--- a/lib/slack-notifier/util/http_client.rb
+++ b/lib/slack-notifier/util/http_client.rb
@@ -2,10 +2,11 @@
 
 require "net/http"
 
-class Slack::Notifier::APIError < StandardError; end
 
 module Slack
   class Notifier
+    class APIError < StandardError; end
+
     module Util
       class HTTPClient
         class << self


### PR DESCRIPTION
The gem can't be loaded. 

```bash
$ ruby -e require "slack-notifier"
/home/pocke/.gem/ruby/2.4.0/gems/slack-notifier-2.2.0/lib/slack-notifier/util/http_client.rb:5:in `<top (required)>': uninitialized constant Slack (NameError)
	from /home/pocke/.gem/ruby/2.4.0/gems/slack-notifier-2.2.0/lib/slack-notifier.rb:5:in `require_relative'
	from /home/pocke/.gem/ruby/2.4.0/gems/slack-notifier-2.2.0/lib/slack-notifier.rb:5:in `<top (required)>'
	from /usr/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `require'
	from /usr/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
	from /usr/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from -e:1:in `<main>'
```

This change fixes the problem.
Could you merge this pull-request and release new version?


related: #76