### PR TITLE
Fix undefined method gsub error with attachment text attribute is nil

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -40,6 +40,7 @@ module Slack
       params  = {}
       client  = payload.delete(:http_client) || config.http_client
       payload = config.defaults.merge(payload)
+      payload = recursive_compact(payload)
 
       params[:http_options] = payload.delete(:http_options) if payload.key?(:http_options)
       params[:payload]      = middleware.call(payload).to_json
@@ -51,6 +52,10 @@ module Slack
 
       def middleware
         @middleware ||= PayloadMiddleware::Stack.new(self)
+      end
+
+      def recursive_compact(hsh)
+        hsh.delete_if {|k,v| recursive_compact(v) if v.is_a?(Hash); v.nil? }
       end
   end
 end

--- a/spec/end_to_end_spec.rb
+++ b/spec/end_to_end_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe Slack::Notifier do
     { text: "hello", channel: "hodor" } =>
     { payload: { text: "hello", channel: "hodor" } },
 
+    { text: nil, attachments: [{ text: "attachment message" }] } =>
+    { payload: { attachments: [{ text: "attachment message" }] } },
+
     { text: "the message", channel: "foo", attachments: [{ color: "#000",
                                                            text: "attachment message",
                                                            fallback: "fallback message" }] } =>
@@ -52,6 +55,12 @@ RSpec.describe Slack::Notifier do
                      fallback: "fallback message" } } =>
     { payload: { attachments: { color: "#000",
                                 text: "attachment message <http://winterfell.com|hodor>",
+                                fallback: "fallback message" } } },
+
+    { attachments: { color: "#000",
+                     text: nil,
+                     fallback: "fallback message" } } =>
+    { payload: { attachments: { color: "#000",
                                 fallback: "fallback message" } } },
 
     { text: "hello", http_options: { timeout: 5 } } =>


### PR DESCRIPTION
If an attachment's `text` attribute is `nil`, `sub_html_links` in `link_formatter.rb` fails with `undefined method 'gsub' for nil:NilClass`. There are probably many different ways to solve this but it seemed most beneficial to me to simply remove attributes that are set to `nil` before processing. Unfortunately, there is no built-in `compact` method for hashes so one is provided here.

For context: our use case includes sending ourselves slack notifications of some types of user-generated content. Without this change, we'd have to conditionally build the individual attachment payloads to prevent setting `text` keys with `nil` values. With this change, `nil` values are simply ignored by the slack notifier library so much less conditional logic is necessary to build slack payloads.

Happy to answer questions or do additional updates if necessary.