### PR TITLE
fix: undefined method gsub in LinkFormatter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- fix error in `LinkFormatter` if a text payload was nil [#81]
+
 # 2.2.1
 - fix loading error caused by uninitialized constant [@pocke #78]
 

--- a/lib/slack-notifier/util/link_formatter.rb
+++ b/lib/slack-notifier/util/link_formatter.rb
@@ -24,6 +24,8 @@ module Slack
 
         # rubocop:disable Style/GuardClause
         def formatted
+          return @orig unless @orig.respond_to?(:gsub)
+
           sub_markdown_links(sub_html_links(@orig))
         rescue => e
           if RUBY_VERSION < "2.1" && e.message.include?("invalid byte sequence")

--- a/spec/end_to_end_spec.rb
+++ b/spec/end_to_end_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Slack::Notifier do
     { payload: { text: "hello", channel: "hodor" } },
 
     { text: nil, attachments: [{ text: "attachment message" }] } =>
-    { payload: { attachments: [{ text: "attachment message" }] } },
+    { payload: { text: nil, attachments: [{ text: "attachment message" }] } },
 
     { text: "the message", channel: "foo", attachments: [{ color: "#000",
                                                            text: "attachment message",
@@ -61,6 +61,7 @@ RSpec.describe Slack::Notifier do
                      text: nil,
                      fallback: "fallback message" } } =>
     { payload: { attachments: { color: "#000",
+                                text: nil,
                                 fallback: "fallback message" } } },
 
     { text: "hello", http_options: { timeout: 5 } } =>

--- a/spec/end_to_end_spec.rb
+++ b/spec/end_to_end_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe Slack::Notifier do
     { text: "hello", channel: "hodor" } =>
     { payload: { text: "hello", channel: "hodor" } },
 
+    { text: nil, attachments: [{ text: "attachment message" }] } =>
+    { payload: { attachments: [{ text: "attachment message" }] } },
+
     { text: "the message", channel: "foo", attachments: [{ color: "#000",
                                                            text: "attachment message",
                                                            fallback: "fallback message" }] } =>
@@ -52,6 +55,12 @@ RSpec.describe Slack::Notifier do
                      fallback: "fallback message" } } =>
     { payload: { attachments: { color: "#000",
                                 text: "attachment message <http://winterfell.com|hodor>",
+                                fallback: "fallback message" } } },
+
+    { attachments: { color: "#000",
+                     text: nil,
+                     fallback: "fallback message" } } =>
+    { payload: { attachments: { color: "#000",
                                 fallback: "fallback message" } } },
 
     { text: "hello", http_options: { timeout: 5 } } =>


### PR DESCRIPTION
Per #81, there are cases where a `:text` key in a message (either in an attachment or the main message) would be passed as `nil`. It may also be possible for an external middleware to expect an object that may not respond to gsub. In both of those cases, LinkFormatter should check for this and only operate on arguments that respond to `gsub`.

This fix will be targeted for a `2.2.2` release.

> cc: @markquezada