### PR TITLE
wrap attachments in an array if given as a single hash

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- fix error in `LinkFormatter` if a text payload was nil [#81]
+
 # 2.2.1
 - fix loading error caused by uninitialized constant [@pocke #78]
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+- fix wrapping of attachments passed as a hash
 - fix error in `LinkFormatter` if a text payload was nil [#81]
 
 # 2.2.1

--- a/lib/slack-notifier/payload_middleware/format_attachments.rb
+++ b/lib/slack-notifier/payload_middleware/format_attachments.rb
@@ -8,15 +8,21 @@ module Slack
         options formats: [:html, :markdown]
 
         def call payload={}
-          attachments = payload.fetch(:attachments, payload["attachments"])
-          wrap_array(attachments).each do |attachment|
+          payload = payload.dup
+          attachments = payload.delete(:attachments)
+          attachments = payload.delete("attachments") unless attachments
+
+          attachments = wrap_array(attachments).map do |attachment|
             ["text", :text].each do |key|
               if attachment.key?(key)
                 attachment[key] = Util::LinkFormatter.format(attachment[key], options)
               end
             end
+
+            attachment
           end
 
+          payload[:attachments] = attachments if attachments && !attachments.empty?
           payload
         end
 

--- a/lib/slack-notifier/util/link_formatter.rb
+++ b/lib/slack-notifier/util/link_formatter.rb
@@ -24,6 +24,8 @@ module Slack
 
         # rubocop:disable Style/GuardClause
         def formatted
+          return @orig unless @orig.respond_to?(:gsub)
+
           sub_markdown_links(sub_html_links(@orig))
         rescue => e
           if RUBY_VERSION < "2.1" && e.message.include?("invalid byte sequence")

--- a/spec/end_to_end_spec.rb
+++ b/spec/end_to_end_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Slack::Notifier do
     { payload: { text: "hello", channel: "hodor" } },
 
     { text: nil, attachments: [{ text: "attachment message" }] } =>
-    { payload: { attachments: [{ text: "attachment message" }] } },
+    { payload: { text: nil, attachments: [{ text: "attachment message" }] } },
 
     { text: "the message", channel: "foo", attachments: [{ color: "#000",
                                                            text: "attachment message",
@@ -61,6 +61,7 @@ RSpec.describe Slack::Notifier do
                      text: nil,
                      fallback: "fallback message" } } =>
     { payload: { attachments: { color: "#000",
+                                text: nil,
                                 fallback: "fallback message" } } },
 
     { text: "hello", http_options: { timeout: 5 } } =>

--- a/spec/end_to_end_spec.rb
+++ b/spec/end_to_end_spec.rb
@@ -53,16 +53,16 @@ RSpec.describe Slack::Notifier do
     { attachments: { color: "#000",
                      text: "attachment message [hodor](http://winterfell.com)",
                      fallback: "fallback message" } } =>
-    { payload: { attachments: { color: "#000",
+    { payload: { attachments: [{ color: "#000",
                                 text: "attachment message <http://winterfell.com|hodor>",
-                                fallback: "fallback message" } } },
+                                fallback: "fallback message" }] } },
 
     { attachments: { color: "#000",
                      text: nil,
                      fallback: "fallback message" } } =>
-    { payload: { attachments: { color: "#000",
+    { payload: { attachments: [{ color: "#000",
                                 text: nil,
-                                fallback: "fallback message" } } },
+                                fallback: "fallback message" }] } },
 
     { text: "hello", http_options: { timeout: 5 } } =>
     { http_options: { timeout: 5 }, payload: { text: "hello" } }

--- a/spec/end_to_end_spec.rb
+++ b/spec/end_to_end_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe Slack::Notifier do
     { text: "hello", channel: "hodor" } =>
     { payload: { text: "hello", channel: "hodor" } },
 
+    { text: nil, attachments: [{ text: "attachment message" }] } =>
+    { payload: { attachments: [{ text: "attachment message" }] } },
+
     { text: "the message", channel: "foo", attachments: [{ color: "#000",
                                                            text: "attachment message",
                                                            fallback: "fallback message" }] } =>
@@ -52,6 +55,12 @@ RSpec.describe Slack::Notifier do
                      fallback: "fallback message" } } =>
     { payload: { attachments: { color: "#000",
                                 text: "attachment message <http://winterfell.com|hodor>",
+                                fallback: "fallback message" } } },
+
+    { attachments: { color: "#000",
+                     text: nil,
+                     fallback: "fallback message" } } =>
+    { payload: { attachments: { color: "#000",
                                 fallback: "fallback message" } } },
 
     { text: "hello", http_options: { timeout: 5 } } =>

--- a/spec/lib/slack-notifier/payload_middleware/format_attachments_spec.rb
+++ b/spec/lib/slack-notifier/payload_middleware/format_attachments_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Slack::Notifier::PayloadMiddleware::FormatAttachments do
     subject.call(attachments: { text: "hello" })
   end
 
+  it "wraps attachment into array if given as a single hash" do
+    params  = {
+      attachments: { text: "hello" }
+    }
+    payload = {
+      attachments: [{ text: "hello" }]
+    }
+    subject = described_class.new(:notifier);
+
+    expect(subject.call(params)).to eq payload
+  end
+
   it "returns the payload unmodified if not :attachments key" do
     payload = { foo: :bar }
     subject = described_class.new(:notifier)


### PR DESCRIPTION
@siegy22 while working on #82 I noticed that we weren't actually wrapping the attachments in an array as they were passed off to the http client to hit slack. Looking back at https://github.com/stevenosloan/slack-notifier/pull/47, I'm not sure if slack has changed there support -- but currently they definitely require them to be formatted as an array (so like `attachments: [{text: "hello"}]`. This all look sane to you?

this PR will be targeted for a `2.2.2` release (ignore the branch name 😬), and is based off of #82 so looking at https://github.com/stevenosloan/slack-notifier/commit/efc5b45400ae5921eea7a7e3395074cd562331eb may make it a bit easier to see.

side note: while writing this I'm thinking a "symbolize keys" middleware will be useful to make access more predictable -- but not necessary for now so that may come later for a 2.3.x release.
