### PR TITLE
Fix post method to return responses by using map instead of each

### DIFF
--- a/lib/slack-notifier.rb
+++ b/lib/slack-notifier.rb
@@ -43,7 +43,7 @@ module Slack
 
       params[:http_options] = payload.delete(:http_options) if payload.key?(:http_options)
 
-      middleware.call(payload).each do |pld|
+      middleware.call(payload).map do |pld|
         params[:payload] = pld.to_json
         client.post endpoint, params
       end

--- a/spec/lib/slack-notifier_spec.rb
+++ b/spec/lib/slack-notifier_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe Slack::Notifier do
         payload: '{"test":"stack"}'
       )
 
-      subject.post
+      responses = subject.post
+      expect(responses).to eq([:posted])
     end
   end
 end


### PR DESCRIPTION
This PR is minor fix.

I wrote code to check whether suceeded API request by the returned value of `Slack::Notifier#post`. It would be a `Net::HTTPOK` in most cases. (I'm not using custom HTTP client)

```ruby
# <= v2.2.2
response = notifier.post text: 'hi'
if response.is_a?(Net::HTTPOK)
  # succeeded
end
```

In v2.3.0, `Slack::Notifier#post`'s returned value seems to be changed from single response object to `Array` for supporting multiple payloads, but we can't get response from this array.

```ruby
# v2.3.0
response = notifier.post text: 'hi'
p response  # [{:text=>"hi"}]
```

We would be able to get it by using `map` instead of `each`.