### PR TITLE
method params syntax (ruby 1.9.3 support)

### DIFF
--- a/lib/slack-notifier/util/link_formatter.rb
+++ b/lib/slack-notifier/util/link_formatter.rb
@@ -17,8 +17,8 @@ module Slack
 
         attr_reader :formats
 
-        def initialize string, formats: [:html, :markdown]
-          @formats = formats
+        def initialize(string, attrs = {})
+          @formats = attrs[:formats] || %i(html markdown)
           @orig    = string.respond_to?(:scrub) ? string.scrub : string
         end
 


### PR DESCRIPTION
minor change, but really important to make this gem support old rubies