### PR TITLE
explicitly convert payload to string.

### DIFF
--- a/lib/slack-notifier/payload_middleware/format_message.rb
+++ b/lib/slack-notifier/payload_middleware/format_message.rb
@@ -9,10 +9,10 @@ module Slack
         options formats: %i[html markdown]
 
         def call payload={}
-          return payload unless payload[:text]
+          return payload.to_s unless payload[:text]
           payload[:text] = Util::LinkFormatter.format(payload[:text], options)
 
-          payload
+          payload.to_s
         end
       end
     end


### PR DESCRIPTION
Explicitly converting payload to string as mattermost is not allowing integers in the payload.