### PR TITLE
Add gem version and SemVer stability badges to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,9 @@
 A simple wrapper to send notifications to [Slack](https://slack.com/) webhooks.
 
-[![Build Status](https://travis-ci.org/stevenosloan/slack-notifier.svg?branch=master)](https://travis-ci.org/stevenosloan/slack-notifier)  [![Code Climate](https://codeclimate.com/github/stevenosloan/slack-notifier.svg)](https://codeclimate.com/github/stevenosloan/slack-notifier)
+[![Build Status](https://travis-ci.org/stevenosloan/slack-notifier.svg?branch=master)](https://travis-ci.org/stevenosloan/slack-notifier)
+[![Code Climate](https://codeclimate.com/github/stevenosloan/slack-notifier.svg)](https://codeclimate.com/github/stevenosloan/slack-notifier)
+[![Gem Version](https://badge.fury.io/rb/slack-notifier.svg)](https://rubygems.org/gems/slack-notifier)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=slack-notifier&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=slack-notifier&package-manager=bundler&version-scheme=semver)
 
 
 ## Example


### PR DESCRIPTION
The badges would now look like this:

[![Build Status](https://travis-ci.org/stevenosloan/slack-notifier.svg?branch=master)](https://travis-ci.org/stevenosloan/slack-notifier) [![Code Climate](https://codeclimate.com/github/stevenosloan/slack-notifier.svg)](https://codeclimate.com/github/stevenosloan/slack-notifier) [![Gem Version](https://badge.fury.io/rb/slack-notifier.svg)](https://rubygems.org/gems/slack-notifier) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=slack-notifier&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=slack-notifier&package-manager=bundler&version-scheme=semver)

The idea behind the version badge is to make it easier for people to add `slack-notifier` to their Gemfile with a version specifier.

The SemVer stability badge is based on data from all of the upgrades of slack-notifier that [Dependabot](https://dependabot.com) has done of slack-notifier for its users (disclosure: I built it). The idea there is to show that releases are consistently SemVer compatible (and 100% is an *awesome* score - normally I consider a score in the 90s as pretty damn good).