### PR TITLE
Change markdown pattern in LinkFormatter to fix parens in url

### DIFF
--- a/lib/slack-notifier/util/link_formatter.rb
+++ b/lib/slack-notifier/util/link_formatter.rb
@@ -14,17 +14,15 @@ module Slack
           </a>
         }x
 
-        # the path portion of a url can contain these characters
-        VALID_PATH_CHARS = '\w\-\.\~\/\?\#\='
+        VALID_URI_CHARS = '\w\-\.\~\:\/\?\#\[\]\@\!\$\&\'\*\+\,\;\='
 
         # Attempt at only matching pairs of parens per
         # the markdown spec http://spec.commonmark.org/0.27/#links
         #
-        # http://rubular.com/r/y107aevxqT
+        # https://rubular.com/r/WfdZ1arvF6PNWO
         MARKDOWN_PATTERN = %r{
             \[ ([^\[\]]*?) \]
-            \( ((https?://.*?) | (mailto:.*?)) \)
-            (?! [#{VALID_PATH_CHARS}]* \) )
+            \( ( (?:https?:\/\/|mailto:) (?:[#{VALID_URI_CHARS}]*?|[#{VALID_URI_CHARS}]*?\([#{VALID_URI_CHARS}]*?\)[#{VALID_URI_CHARS}]*?) ) \)
         }x
 
         class << self

--- a/spec/lib/slack-notifier/util/link_formatter_spec.rb
+++ b/spec/lib/slack-notifier/util/link_formatter_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Slack::Notifier::Util::LinkFormatter do
       expect(formatted).to eq("Hello World, enjoy [<http://example.com|this> in brackets].")
     end
 
+    it "formats markdown links in parens" do
+      formatted = described_class.format("Hello World, enjoy ([this](http://example.com)) in parens.")
+      expect(formatted).to eq("Hello World, enjoy (<http://example.com|this>) in parens.")
+    end
+
     it "formats markdown links with no title" do
       formatted = described_class.format("Hello World, enjoy [](http://example.com).")
       expect(formatted).to include("<http://example.com>")


### PR DESCRIPTION
Fixes #105

Changed the regexp pattern for markdown links to work correctly with parenthesis.

Also see: https://rubular.com/r/WfdZ1arvF6PNWO