### PR TITLE
Resolve warning in ruby2.7.

### DIFF
--- a/lib/slack-notifier/util/link_formatter.rb
+++ b/lib/slack-notifier/util/link_formatter.rb
@@ -29,7 +29,7 @@ module Slack
 
         class << self
           def format string, opts={}
-            LinkFormatter.new(string, opts).formatted
+            LinkFormatter.new(string, **opts).formatted
           end
         end
 


### PR DESCRIPTION
Resolved the warning displayed when running Ruby 2.7, which is also talked about in this issue(https://github.com/stevenosloan/slack-notifier/issues/115). 