### PR TITLE
Fix keyword arguments error in ruby 3.0

### DIFF
--- a/lib/slack-notifier/util/link_formatter.rb
+++ b/lib/slack-notifier/util/link_formatter.rb
@@ -29,7 +29,7 @@ module Slack
 
         class << self
           def format string, opts={}
-            LinkFormatter.new(string, opts).formatted
+            LinkFormatter.new(string, **opts).formatted
           end
         end
 


### PR DESCRIPTION
Use `Slack::Notifier#ping` on Ruby 3.0.0, raise following error.

```
ArgumentError:
  wrong number of arguments (given 2, expected 1)
# /usr/local/bundle/gems/slack-notifier-2.3.2/lib/slack-notifier/util/link_formatter.rb:38:in `initialize'
```

Fix keyword argument error start with Ruby 3.0.0.