### PR TITLE
Update `RubyDoc.org` URL link in readme.md to Ruby version `3.0.1`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ notifier = Slack::Notifier.new 'WEBHOOK_URL', http_options: { open_timeout: 5 }
 notifier.post text: "hello", http_options: { open_timeout: 10 }
 ```
 
-**Note**: you should only send along options that [`Net::HTTP`](http://ruby-doc.org/stdlib-2.2.0/libdoc/net/http/rdoc/Net/HTTP.html) has as setters, otherwise the option will be ignored and show a warning.
+**Note**: you should only send along options that [`Net::HTTP`](https://ruby-doc.org/stdlib-3.0.1/libdoc/net/http/rdoc/Net/HTTP.html) has as setters, otherwise the option will be ignored and show a warning.
 
 ### Proxies
 
@@ -183,7 +183,7 @@ notifier = Slack::Notifier.new 'WEBHOOK_URL', http_options: {
 
 ## Custom HTTP Client
 
-There is a packaged default client wrapping Net::HTTP, but your HTTP needs might be a little different. In that case, you can pass in your own wrapper to handle sending the notifications. It just needs to respond to `::post` with the arguments of the endpoint URI, and the payload [pretty much the same as Net:HTTP.post_form](http://ruby-doc.org/stdlib-2.1.2/libdoc/net/http/rdoc/Net/HTTP.html#method-c-post_form).
+There is a packaged default client wrapping Net::HTTP, but your HTTP needs might be a little different. In that case, you can pass in your own wrapper to handle sending the notifications. It just needs to respond to `::post` with the arguments of the endpoint URI, and the payload [pretty much the same as Net::HTTP.post_form](https://ruby-doc.org/stdlib-3.0.1/libdoc/net/http/rdoc/Net/HTTP.html#method-c-post_form).
 
 A simple example:
 ```ruby


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21003135/118354543-7958e680-b5a6-11eb-92e9-8290d51b74c1.png)

The URL link to `RubyDoc.org` in readme.md was a reference toan older version of Ruby (`2.1` or `2.2`) that is no longer supported.

The document of Ruby `3.0.1` version already exists in `RubyDoc.org`,and `slack-notifier` gem supports Ruby `3.0`.

I think it's better to use the URL link to `RubyDoc.org` of version `3.0` in readme.md.