### PR TITLE
Show an explicit changelog link on rubygems page

### DIFF
--- a/slack-notifier.gemspec
+++ b/slack-notifier.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Steven Sloan"]
   s.email         = ["stevenosloan@gmail.com"]
   s.homepage      = "https://github.com/slack-notifier/slack-notifier"
+  s.metadata      = { "changelog_uri" => "https://github.com/slack-notifier/slack-notifier/blob/main/changelog.md" }
   s.license       = "MIT"
 
   s.files         = Dir["{lib}/**/*.rb"]


### PR DESCRIPTION
An example of what it would look like:
https://rubygems.org/gems/retryable

https://github.com/nfedyashev/retryable/blob/master/retryable.gemspec#L18