### PR TITLE
escape html using native `#encode`

### DIFF
--- a/lib/slack-notifier/util/escape.rb
+++ b/lib/slack-notifier/util/escape.rb
@@ -4,11 +4,8 @@ module Slack
   class Notifier
     module Util
       module Escape
-        HTML_REGEXP  = /[&><]/
-        HTML_REPLACE = { "&" => "&amp;", ">" => "&gt;", "<" => "&lt;" }.freeze
-
         def self.html string
-          string.gsub(HTML_REGEXP, HTML_REPLACE)
+          string.encode(xml: :text)
         end
       end
     end


### PR DESCRIPTION
ref: https://ruby-doc.org/core-3.1.0/String.html#encode-method

> The value must be :text or :attr. If the value is :text [encode](https://ruby-doc.org/core-3.1.0/String.html#method-i-encode) replaces undefined characters with their (upper-case hexadecimal) numeric character references. '&', '<', and '>' are converted to “&amp;”, “&lt;”, and “&gt;”, respectively. If the value is :attr, [encode](https://ruby-doc.org/core-3.1.0/String.html#method-i-encode) also quotes the replacement result (using '“'), and replaces '”' with “&quot;”.